### PR TITLE
Config elecom private mib (2)

### DIFF
--- a/.github/workflows/config_file_generator_for_snmp_exporter.yml
+++ b/.github/workflows/config_file_generator_for_snmp_exporter.yml
@@ -153,9 +153,9 @@ jobs:
           # Require for Elecom WAB-S1167-PS Private MIB
           echo 'List segments: ' && ls .
 
-          # $HOME/work/snmp_exporter/private_mib/WAB-S1167-PS-FW-V1-5-6/elecom_private_mib_v1.4.17.mib を $HOME/work/snmp_exporter/generator/mibs に移動する
+          # $GITHUB_WORKSPACE/snmp_exporter/private_mib/WAB-S1167-PS-FW-V1-5-6/elecom_private_mib_v1.4.17.mib を $HOME/work/snmp_exporter/generator/mibs に移動する
           cd $HOME/work/snmp_exporter/generator/mibs/
-          mv $HOME/work/snmp_exporter/private_mib/WAB-S1167-PS-FW-V1-5-6/elecom_private_mib_v1.4.17.mib ./
+          mv $GITHUB_WORKSPACE/snmp_exporter/private_mib/WAB-S1167-PS-FW-V1-5-6/elecom_private_mib_v1.4.17.mib ./
 
           # $HOME/work/snmp_exporter/generator/ に戻る
           cd ../


### PR DESCRIPTION
https://github.com/yu1k/monitoring-server/pull/1 の続き

$GITHUB_WORKSPACE 以下のファイルを移動したいのに、存在しない $HOME/work/ 以下のファイルを移動しようとしていたのでエラーが出ていた。対処として、PATHを修正した。